### PR TITLE
Use regex to determine if node is leaf node instead of substring

### DIFF
--- a/xgbfir/main.py
+++ b/xgbfir/main.py
@@ -261,8 +261,9 @@ class XgbModelParser:
 
     def ParseXgbTreeNode(self, line):
         node = XgbTreeNode()
-        if "leaf" in line:
-            m = self.leafRegex.match(line)
+
+        m = self.leafRegex.match(line)
+        if m:
             node.Number = int(m.group(1))
             node.LeafValue = float(m.group(2))
             node.Cover = float(m.group(3))


### PR DESCRIPTION
Very small change. Parsing was failing for a feature name containing the substring leaf ("mapleleaf"). Repro by changing the first feature name in the boston dump to "leaf" and try loading.